### PR TITLE
resolve #31

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountController.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountController.java
@@ -36,7 +36,6 @@ public class AccountController {
 
     private void validate(AccountDto accountDto) {
         Errors errors = new BeanPropertyBindingResult(accountDto, "account");
-        log.info("controller validate");
         accountValidator.validate(accountDto, errors);
         if (errors.hasErrors()) {
             log.info("controller validate errors");

--- a/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountService.java
@@ -46,8 +46,7 @@ public class AccountService implements ReactiveUserDetailsService {
             user.setPassword(passwordEncoder.encode(user.getPassword()));
             user.setRoles(Collections.singletonList(Role.USER));
             return modelMapper.map(user, Account.class);
-        })
-                .flatMap(user -> accountRepository.findByEmail(user.getEmail())
+        }).flatMap(user -> accountRepository.findByEmail(user.getEmail())
                         .map(dupUser -> ResponseEntity.badRequest().build())
                         .switchIfEmpty(accountRepository.save(user)
                                 .map(saveUser -> new ResponseEntity<>(saveUser, HttpStatus.CREATED))));

--- a/twitterclone/src/main/java/me/dblab/twitterclone/follow/FollowService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/follow/FollowService.java
@@ -39,7 +39,7 @@ public class FollowService {
         return followRepository.deleteById(id);
     }
 
-    public Flux<Follow> findFollowingEmail(String userEmail) {
-        return followRepository.findAllByFollowerEmail(userEmail);
+    public Flux<Follow> findFollowingEmails(String followerEmail) {
+        return followRepository.findAllByFollowerEmail(followerEmail);
     }
 }

--- a/twitterclone/src/main/java/me/dblab/twitterclone/tweet/Tweet.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/tweet/Tweet.java
@@ -1,7 +1,6 @@
 package me.dblab.twitterclone.tweet;
 
 import lombok.*;
-import me.dblab.twitterclone.account.Account;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -19,5 +18,5 @@ public class Tweet {
 
     private LocalDateTime createdDate;
 
-    private Account account;
+    private String authorEmail;
 }

--- a/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetRepository.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetRepository.java
@@ -1,9 +1,9 @@
 package me.dblab.twitterclone.tweet;
 
-import me.dblab.twitterclone.account.Account;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import reactor.core.publisher.Flux;
 
 public interface TweetRepository extends ReactiveMongoRepository<Tweet, String> {
-    Flux<Tweet> findAllByAccount(Account account);
+    Flux<Tweet> findAllByAuthorEmailOrderByCreatedDateDesc(String email);
+    Flux<Tweet> findAllByAuthorEmail(String email);
 }

--- a/twitterclone/src/test/java/me/dblab/twitterclone/tweet/TweetControllerTest.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/tweet/TweetControllerTest.java
@@ -1,8 +1,6 @@
 package me.dblab.twitterclone.tweet;
 
-import me.dblab.twitterclone.account.Account;
-import me.dblab.twitterclone.account.AccountDto;
-import me.dblab.twitterclone.account.AccountRepository;
+import me.dblab.twitterclone.account.*;
 import me.dblab.twitterclone.common.BaseControllerTest;
 import me.dblab.twitterclone.config.jwt.TokenProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,9 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -26,6 +29,12 @@ public class TweetControllerTest extends BaseControllerTest {
     TweetRepository tweetRepository;
 
     @Autowired
+    TweetService tweetService;
+
+    @Autowired
+    AccountService accountService;
+
+    @Autowired
     TokenProvider tokenProvider;
 
     private final String tweetUrl = "/api/tweets";
@@ -34,11 +43,13 @@ public class TweetControllerTest extends BaseControllerTest {
     @Autowired
     AccountRepository accountRepository;
 
+    private final String accountUrl = "/api/users";
+
     @BeforeEach
     void setUp() {
+        tweetRepository.deleteAll().then(accountRepository.deleteAll()).subscribe();
         AccountDto account = createAccountDto();
 
-        String accountUrl = "/api/users";
         webTestClient.post()
                 .uri(accountUrl)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -71,12 +82,12 @@ public class TweetControllerTest extends BaseControllerTest {
                 .expectStatus()
                 .isCreated();
 
-        Flux<Tweet> allByAccount = tweetRepository.findAllByAccount(currentAccount());
+        Flux<Tweet> allByAccount = tweetRepository.findAllByAuthorEmail(currentAccount());
 
         StepVerifier.create(allByAccount)
                 .assertNext(tweetObj -> {
                     then(tweetObj.getContent()).isEqualTo("경성대학교 C동 528호");
-                    then(tweetObj.getAccount().getEmail()).isEqualTo(appProperties.getTestEmail());
+                    then(tweetObj.getAuthorEmail()).isEqualTo(appProperties.getTestEmail());
                 })
                 .verifyComplete();
     }
@@ -87,7 +98,7 @@ public class TweetControllerTest extends BaseControllerTest {
         TweetDto tweetDto = tweetBuilder();
         createTweet(tweetDto);
 
-        Flux<Tweet> allByAccount = tweetRepository.findAllByAccount(currentAccount());
+        Flux<Tweet> allByAccount = tweetRepository.findAllByAuthorEmail(currentAccount());
         allByAccount.doOnNext(tweet -> webTestClient.delete()
                     .uri(tweetUrl + "/" + tweet.getId())
                     .header(HttpHeaders.AUTHORIZATION, jwt)
@@ -105,7 +116,7 @@ public class TweetControllerTest extends BaseControllerTest {
         TweetDto tweetDto = tweetBuilder();
         createTweet(tweetDto);
 
-        Flux<Tweet> allByAccount = tweetRepository.findAllByAccount(currentAccount());
+        Flux<Tweet> allByAccount = tweetRepository.findAllByAuthorEmail(currentAccount());
         allByAccount.doOnNext(tweet -> webTestClient.get()
                 .uri(tweetUrl + "/" + tweet.getId())
                 .header(HttpHeaders.AUTHORIZATION, jwt)
@@ -125,7 +136,7 @@ public class TweetControllerTest extends BaseControllerTest {
         createTweet(tweetDto);
 
         String update_content = "update content";
-        Flux<Tweet> allByAccount = tweetRepository.findAllByAccount(currentAccount());
+        Flux<Tweet> allByAccount = tweetRepository.findAllByAuthorEmail(currentAccount());
 
         allByAccount.doOnNext(tweet -> {
             tweetDto.setContent(update_content);
@@ -143,33 +154,130 @@ public class TweetControllerTest extends BaseControllerTest {
                                     then(tweet1.getId()).isEqualTo(tweet.getId());
                                     then(tweet1.getContent()).isEqualTo(update_content);
                                 }).verifyComplete());
-
     }
 
-    private Account currentAccount() throws Exception {
-        Mono<Account> byEmail = accountRepository.findByEmail(tokenProvider.getUsernameFromToken(jwt.replace("Bearer ", "")));
-        return byEmail.block();
+    @Test
+    @DisplayName("유저가 팔로잉한 유저들의 게시물만 불러오기")
+    public void getTweetList() {
+        //유저 10명 생성 & 등록
+        IntStream.rangeClosed(1, 10).forEach(index -> {
+            AccountDto accountDto = createAccountDto(index);
+            webTestClient.post()
+                    .uri(accountUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Mono.just(accountDto), Account.class)
+                    .exchange()
+                    .expectStatus()
+                    .isCreated();
+
+            StepVerifier.create(accountRepository.findByEmail(createEmail(index)))
+                    .assertNext(account -> then(account.getEmail()).isEqualTo(createEmail(index)))
+                    .verifyComplete();
+        });
+
+        //유저 10명에게 각각 1개의 트윗 등록
+        IntStream.rangeClosed(1, 10).forEach(index -> {
+            TweetDto tweetDto = new TweetDto();
+            tweetDto.setContent("경성대 투썸플레이스" + index);
+            try {
+                createTweet(tweetDto, index);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        //검증
+        IntStream.rangeClosed(1, 10).forEach(index ->
+            StepVerifier.create(tweetRepository.findAllByAuthorEmail(createEmail(index)))
+                    .assertNext(tweet -> then(tweet.getAuthorEmail()).isEqualTo(createEmail(index)))
+                    .verifyComplete()
+        );
+
+        Mono<Account> byEmail = accountRepository.findByEmail(appProperties.getTestEmail());
+        //5명만 팔로잉
+        Account account = byEmail.block();
+        jwt = "Bearer " + tokenProvider.generateToken(account);
+        IntStream.rangeClosed(1, 5).forEach(index ->
+            webTestClient.post()
+                    .uri("/api/follows/" + createEmail(index))
+                    .header(HttpHeaders.AUTHORIZATION, jwt)
+                    .exchange()
+                    .expectStatus()
+                    .isCreated()
+        );
+
+        //검증
+        webTestClient.get()
+                .uri(tweetUrl)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("[*].content").exists();
+
+        IntStream.rangeClosed(1, 5)
+                .forEach(index ->
+                    StepVerifier.create(tweetRepository.findAllByAuthorEmailOrderByCreatedDateDesc(createEmail(index)))
+                            .assertNext(tweet -> then(tweet.getAuthorEmail()).isEqualTo(createEmail(index)))
+                            .verifyComplete()
+                );
     }
 
-    private void createTweet(TweetDto tweetDto) {
+    private void createTweet(TweetDto tweetDto, int index) throws Exception {
+        SecurityContextHolder.clearContext();
+        Mono<Account> byEmail = accountRepository.findByEmail(createEmail(index));
+        jwt = "Bearer " + tokenProvider.generateToken(byEmail.block());
+
         webTestClient.post()
                 .uri(tweetUrl)
                 .header(HttpHeaders.AUTHORIZATION, jwt)
-                .body(Mono.just(tweetDto), Tweet.class)
+                .body(Mono.just(tweetDto), TweetDto.class)
                 .exchange()
                 .expectStatus()
                 .isCreated();
 
-        Mono<Account> byEmail = accountRepository.findByEmail(appProperties.getTestEmail());
-
-        StepVerifier.create(tweetRepository.findAllByAccount(byEmail.block()))
-                .assertNext(tweetObj -> then(tweetObj.getContent()).isEqualTo("경성대학교 C동 528호"))
+        StepVerifier.create(tweetRepository.findAllByAuthorEmail(currentAccount()))
+                .assertNext(tweetObj -> then(tweetObj).isNotNull())
                 .verifyComplete();
+    }
+
+    private void createTweet(TweetDto tweetDto) throws Exception {
+        webTestClient.post()
+                .uri(tweetUrl)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .body(Mono.just(tweetDto), TweetDto.class)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+
+        StepVerifier.create(tweetRepository.findAllByAuthorEmail(currentAccount()))
+                .assertNext(tweetObj -> then(tweetObj).isNotNull())
+                .verifyComplete();
+    }
+
+    private String currentAccount() throws Exception {
+        Mono<Account> byEmail = accountRepository.findByEmail(tokenProvider.getUsernameFromToken(jwt.replace("Bearer ", "")));
+        return Objects.requireNonNull(byEmail.block()).getEmail();
     }
 
     private TweetDto tweetBuilder() {
         TweetDto tweetDto = new TweetDto();
         tweetDto.setContent("경성대학교 C동 528호");
         return tweetDto;
+    }
+
+    private String createEmail(int index) {
+        return "test" + index + "@gmail.com";
+    }
+
+    private AccountDto createAccountDto(int index) {
+        return AccountDto.builder()
+                .email(createEmail(index))
+                .username(appProperties.getTestUsername())
+                .password(appProperties.getTestPassword())
+                .nickname(appProperties.getTestNickname())
+                .roles(Collections.singletonList(Role.USER))
+                .build();
     }
 }

--- a/twitterclone/src/test/java/me/dblab/twitterclone/tweet/TweetValidatorTest.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/tweet/TweetValidatorTest.java
@@ -30,6 +30,8 @@ public class TweetValidatorTest extends BaseControllerTest {
 
     private String jwt;
 
+    private final String tweetUrl = "/api/tweets";
+
     @BeforeEach
     public void setUp() {
         accountRepository.deleteAll().then(tweetRepository.deleteAll()).subscribe();
@@ -60,8 +62,6 @@ public class TweetValidatorTest extends BaseControllerTest {
     @Test
     @DisplayName("컨텐츠의 길이가 0일때")
     public void contentValidate_less_than_1() {
-        String tweetUrl = "/api/tweets";
-
         //트윗 생성
         TweetDto tweetDto = new TweetDto();
         tweetDto.setContent("");
@@ -81,7 +81,6 @@ public class TweetValidatorTest extends BaseControllerTest {
     @Test
     @DisplayName("컨텐츠의 길이가 255이상 일 때")
     public void contentValidate_length_greater_than_255() {
-        String tweetUrl = "/api/tweets";
         String randomString = RandomStringUtils.random(256);
 
         then(randomString.length()).isGreaterThan(255);
@@ -104,10 +103,6 @@ public class TweetValidatorTest extends BaseControllerTest {
     @Test
     @DisplayName("컨텐츠가 null일 때")
     public void contentValidate_null() {
-        String tweetUrl = "/api/tweets";
-        String randomString = RandomStringUtils.random(256);
-
-        then(randomString.length()).isGreaterThan(255);
         //트윗 생성
         TweetDto tweetDto = new TweetDto();
 


### PR DESCRIPTION
- GET(/api/tweets) 호출 시 팔로잉한 유저의 게시물만 호출되도록 변경함
- Test
  - 원래 10명의 유저를 생성하고, 유저 당 30개씩 트윗을 생성하려고
  했는데, timeout이 계속 발생하여 10명의 유저에게 1개의 트윗을 생성하고
  검증했음
- resolve : #31 