### PR TITLE
issue #33

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/config/SecurityConfig.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/config/SecurityConfig.java
@@ -12,13 +12,15 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.reactive.config.CorsRegistry;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 @EnableWebFluxSecurity
 @Configuration
-public class SecurityConfig {
-
+public class SecurityConfig implements WebFluxConfigurer {
 
     private final AuthenticationManager authenticationManager;
 
@@ -29,12 +31,20 @@ public class SecurityConfig {
         this.securityContextRepository = securityContextRepository;
     }
 
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods(CorsConfiguration.ALL)
+                .allowedHeaders(CorsConfiguration.ALL);
+    }
+
     @Bean
     SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
         String userApi = "/api/users";
         String[] patterns = new String[]{userApi, userApi + "/login"};
 
-        return http.cors().disable()
+        return http
                 .exceptionHandling()
                 .authenticationEntryPoint((swe, e) -> Mono.fromRunnable(() ->
                     swe.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED)

--- a/twitterclone/src/test/java/me/dblab/twitterclone/account/AccountControllerTests.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/account/AccountControllerTests.java
@@ -10,11 +10,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Date;
-
 import static org.assertj.core.api.BDDAssertions.then;
 
 

--- a/twitterclone/src/test/java/me/dblab/twitterclone/config/SecurityConfigTest.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/config/SecurityConfigTest.java
@@ -1,28 +1,65 @@
 package me.dblab.twitterclone.config;
 
+import me.dblab.twitterclone.account.AccountDto;
+import me.dblab.twitterclone.common.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
-public class SecurityConfigTest {
+public class SecurityConfigTest extends BaseControllerTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    private final String baseUrl = "http://localhost:8080";
+    private final String userUrl = "/api/users";
+
     @Test
+    @DisplayName("PasswordEncoder 검증")
     public void encodeTest() {
-
         String password = "testpassword";
-
         String encode = passwordEncoder.encode(password);
-
         then(passwordEncoder.matches(password, encode)).isTrue();
+    }
+
+    @Test
+    @DisplayName("허용한 Origin 에서 요청했을 때")
+    public void corsTest() {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.newInstance().host("localhost").port(3000);
+        UriComponents host = uriBuilder.build();
+        UriComponents origin = uriBuilder.scheme("http").build();
+
+        webTestClient
+                .mutate().baseUrl(baseUrl).build()
+                .post()
+                .uri(userUrl)
+                .header(HttpHeaders.HOST, host.toUriString())
+                .header(HttpHeaders.ORIGIN, origin.toUriString())
+                .header(HttpHeaders.REFERER, origin.toUriString() + "/signup")
+                .body(Mono.just(createAccountDto()), AccountDto.class)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+    }
+
+    @Test
+    @DisplayName("허용하지 않은 Origin에서 요청했을 때")
+    public void corsTest_forbidden() {
+        webTestClient
+                .mutate().baseUrl(baseUrl).build()
+                .post()
+                .uri(userUrl)
+                .header(HttpHeaders.ORIGIN, "http://any-origin.com")
+                .body(Mono.just(createAccountDto()), AccountDto.class)
+                .exchange()
+                .expectStatus()
+                .isForbidden();
     }
 }


### PR DESCRIPTION
- [spring document](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html#webflux-cors)를 참조하여 작성하였다.
- 테스트 코드를 작성할 때 처음에는 
~~~java
UriComponentsBuilder uriBuilder = UriComponentsBuilder.newInstance().host("localhost").port(3000);
        UriComponents host = uriBuilder.build();
        UriComponents origin = uriBuilder.scheme("http").build();

        webTestClient
                .post()
                .uri(userUrl)
                .header(HttpHeaders.HOST, host.toUriString())
                .header(HttpHeaders.ORIGIN, origin.toUriString())
                .header(HttpHeaders.REFERER, origin.toUriString() + "/signup")
                .body(Mono.just(createAccountDto()), AccountDto.class)
                .exchange()
                .expectStatus()
                .isCreated();
~~~
- 같이 작성하였는데,  `IllegalArgumentException: Actual request scheme must not be null`가 발생하여 구글링 해봤지만, 해결방법을 찾지 못했다. 그런데 `.mutate().baseUrl("localhost:8080").build()`을 추가하니 테스트가 성공하였다. 다른 테스트에서는 추가하지않아도 테스트가 성공했었는데, 이번 테스트에서 추가한 
~~~java
.header(HttpHeaders.HOST, host.toUriString())
.header(HttpHeaders.ORIGIN, origin.toUriString())
.header(HttpHeaders.REFERER, origin.toUriString() + "/signup")
~~~
- 코드 때문에 발생한 `Exception` 인 것으로 생각된다. 정확한 것은 조금 더 알아봐야 할 것 같다.
- resovle : #33 