### PR TITLE
issue #39

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetController.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetController.java
@@ -45,8 +45,7 @@ public class TweetController {
     }
 
     @DeleteMapping(value = "/{id}")
-    @ResponseStatus(HttpStatus.OK)
-    public Mono<Void> deleteTweet(@PathVariable String id) {
+    public Mono<ResponseEntity> deleteTweet(@PathVariable String id) {
         return tweetService.deleteTweet(id);
     }
 


### PR DESCRIPTION
- `getTweetList` 테스트 시 잘 동작하던 `SecurityContextHolder.clearContext()` 를 사용하니 `       SecurityContextHolder.getContext().getAuthentication()`에서 `NPE`가 발생했다. 그래서 `SecurityContextHolder.getContext().setAuthentication(null)`을 사용하니 테스트가 통과하였다.
로그를 찍어보니 `jwt`도 찍혀 무엇이 문제인지 잘 모르겠다. 
`SecurityContextHolder.clearContext()`가 어떻게 동작하는지 알아보아야 겠다.
- resolve : #39 