### PR TITLE
Create Explore

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/Explore.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/Explore.java
@@ -1,0 +1,20 @@
+package me.dblab.twitterclone.explore;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import java.time.LocalDateTime;
+
+@Setter @Getter
+@AllArgsConstructor @NoArgsConstructor
+@Builder @Document
+public class Explore {
+
+    @Id
+    private String id;
+    private String keyword;
+    private boolean isSaved;
+    private LocalDateTime searchedAt;
+    private String accountEmail;
+
+}

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreController.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreController.java
@@ -1,0 +1,56 @@
+package me.dblab.twitterclone.explore;
+
+import lombok.RequiredArgsConstructor;
+import me.dblab.twitterclone.tweet.Tweet;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/explores")
+public class ExploreController {
+
+    private final ExploreService exploreService;
+    private final ExploreValidator exploreValidator;
+
+    @GetMapping
+    public Flux<Explore> getSavedExplore()   {
+        return exploreService.getSavedExplore();
+    }
+
+    @PostMapping("/keywords")
+    public Flux<Tweet> getTweetListBySearch(@RequestBody ExploreDto exploreDto)   {
+        return Mono.just(exploreDto)
+                .filter(this::validate)
+                .flatMapMany(exploreService::getTweetListByKeyword)
+                .switchIfEmpty(Flux.empty());
+    }
+
+    @PostMapping
+    public Mono<ResponseEntity> saveKeyword(@RequestBody ExploreDto exploreDto)    {
+        return Mono.just(exploreDto)
+                .filter(this::validate)
+                .flatMap(exploreService::saveKeyword)
+                .switchIfEmpty(Mono.just(ResponseEntity.badRequest().build()));
+    }
+
+    @DeleteMapping("/{exploreId}")
+    public Mono<ResponseEntity<Void>> deleteKeyword(@PathVariable String exploreId) {
+        return exploreService.deleteKeyword(exploreId);
+    }
+
+    private boolean validate(ExploreDto exploreDto) {
+        Errors errors = new BeanPropertyBindingResult(exploreDto, "Explore");
+        this.exploreValidator.validate(exploreDto, errors);
+        if (errors.hasErrors()) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreController.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreController.java
@@ -2,7 +2,6 @@ package me.dblab.twitterclone.explore;
 
 import lombok.RequiredArgsConstructor;
 import me.dblab.twitterclone.tweet.Tweet;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Errors;

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreDto.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreDto.java
@@ -1,0 +1,12 @@
+package me.dblab.twitterclone.explore;
+
+import lombok.*;
+
+@Setter @Getter
+@AllArgsConstructor @NoArgsConstructor
+@Builder
+public class ExploreDto {
+
+    private String keyword;
+
+}

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreRepository.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreRepository.java
@@ -1,0 +1,10 @@
+package me.dblab.twitterclone.explore;
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ExploreRepository extends ReactiveMongoRepository<Explore, String> {
+    Flux<Explore> findAllByAccountEmailOrderByKeyword(String email);
+    Mono<Void> deleteAllByKeywordAndAccountEmail(String keyword, String accountEmail);
+}

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -50,11 +49,6 @@ public class ExploreService {
                         .flatMap(acc2 -> exploreRepository.deleteAllByKeywordAndAccountEmail(acc2.getKeyword(), acc2.getAccountEmail())
                                 .then(Mono.just(new ResponseEntity<Void>(HttpStatus.OK)))))
                 .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.BAD_REQUEST)));
-
-//        return exploreRepository.findById(id)
-//                .flatMap(acc -> exploreRepository.deleteAllByKeywordAndAccountEmail(acc.getKeyword(), acc.getAccountEmail())
-//                        .then(Mono.just(new ResponseEntity<Void>(HttpStatus.OK))))
-//                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.BAD_REQUEST)));
     }
 
     private Mono<Explore> saveExplore(ExploreDto exploreDto)  {

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreService.java
@@ -1,0 +1,70 @@
+package me.dblab.twitterclone.explore;
+
+import lombok.RequiredArgsConstructor;
+import me.dblab.twitterclone.account.AccountService;
+import me.dblab.twitterclone.tweet.Tweet;
+import me.dblab.twitterclone.tweet.TweetRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class ExploreService {
+
+    private final ExploreRepository exploreRepository;
+    private final AccountService accountService;
+    private final ModelMapper modelMapper;
+    private final TweetRepository tweetRepository;
+
+    public Flux<Explore> getSavedExplore() {
+        return accountService.findCurrentUser()
+                .flatMapMany(ac -> exploreRepository.findAllByAccountEmailOrderByKeyword(ac.getEmail())
+                        .filter(Explore::isSaved));
+    }
+
+    public Flux<Tweet> getTweetListByKeyword(ExploreDto exploreDto) {
+        return saveExplore(exploreDto)
+                .flatMap(exploreRepository::save)
+                .flatMapMany(exp -> tweetRepository.findAllByContentContainingOrderByCreatedDateDesc(exp.getKeyword()));
+    }
+
+    public Mono<ResponseEntity> saveKeyword(ExploreDto exploreDto) {
+        return saveExplore(exploreDto)
+                .map(explore -> {
+                    explore.setSaved(true);
+                    return explore;
+                })
+                .flatMap(exploreRepository::save)
+                .map(saveExplore -> new ResponseEntity<>(saveExplore, HttpStatus.CREATED));
+    }
+
+    public Mono<ResponseEntity<Void>> deleteKeyword(String id) {
+        return accountService.findCurrentUser()
+                .flatMap(acc -> exploreRepository.findById(id).filter(exp -> exp.getAccountEmail().equals(acc.getEmail()))
+                        .flatMap(acc2 -> exploreRepository.deleteAllByKeywordAndAccountEmail(acc2.getKeyword(), acc2.getAccountEmail())
+                                .then(Mono.just(new ResponseEntity<Void>(HttpStatus.OK)))))
+                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.BAD_REQUEST)));
+
+//        return exploreRepository.findById(id)
+//                .flatMap(acc -> exploreRepository.deleteAllByKeywordAndAccountEmail(acc.getKeyword(), acc.getAccountEmail())
+//                        .then(Mono.just(new ResponseEntity<Void>(HttpStatus.OK))))
+//                .switchIfEmpty(Mono.just(new ResponseEntity<>(HttpStatus.BAD_REQUEST)));
+    }
+
+    private Mono<Explore> saveExplore(ExploreDto exploreDto)  {
+        return accountService.findCurrentUser()
+                .map(ac -> {
+                    Explore explore = modelMapper.map(exploreDto, Explore.class);
+                    explore.setAccountEmail(ac.getEmail());
+                    explore.setSearchedAt(LocalDateTime.now());
+                    explore.setSaved(false);
+                    return explore;
+                });
+    }
+}

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreValidator.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreValidator.java
@@ -1,0 +1,22 @@
+package me.dblab.twitterclone.explore;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Component
+public class ExploreValidator implements Validator {
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return ExploreDto.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        ExploreDto exploreDto = (ExploreDto) target;
+
+        if (exploreDto.getKeyword() == null || "".equals(exploreDto.getKeyword().trim())) {
+            errors.rejectValue("keyword", "wrongValue", "Keyword cannot be null.");
+        }
+    }
+}

--- a/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetRepository.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetRepository.java
@@ -9,4 +9,5 @@ public interface TweetRepository extends ReactiveMongoRepository<Tweet, String> 
     Flux<Tweet> findAllByAuthorEmailOrderByCreatedDateDesc(String email);
     Flux<Tweet> findAllByAuthorEmail(String email);
     Mono<Tweet> findByAuthorEmail(String email);    // test용
+    Flux<Tweet> findAllByContentContainingOrderByCreatedDateDesc(String keyword);
 }

--- a/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetService.java
@@ -14,11 +14,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service

--- a/twitterclone/src/test/java/me/dblab/twitterclone/explore/ExploreControllerTests.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/explore/ExploreControllerTests.java
@@ -214,8 +214,6 @@ public class ExploreControllerTests extends BaseControllerTest {
 
         Flux<Explore> exploreFlux = exploreRepository.findAllByAccountEmailOrderByKeyword(currentAccount());
         Explore explore = exploreFlux.blockLast();
-        log.info("explore 주인 : " + explore.getAccountEmail());
-        log.info("currentAccount : " + explore.getAccountEmail());
         AccountDto anotherAccountDto = createAnotherAccountDto();
 
         webTestClient.post()
@@ -228,7 +226,6 @@ public class ExploreControllerTests extends BaseControllerTest {
 
         Mono<Account> byEmail2 = accountRepository.findByEmail(anotherAccountDto.getEmail());
         Account account = byEmail2.block();
-        log.info("account : " + account.getEmail());
         String jwt2 = BEARER + tokenProvider.generateToken(account);
 
         webTestClient.delete()

--- a/twitterclone/src/test/java/me/dblab/twitterclone/explore/ExploreControllerTests.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/explore/ExploreControllerTests.java
@@ -1,0 +1,287 @@
+package me.dblab.twitterclone.explore;
+
+import lombok.extern.slf4j.Slf4j;
+import me.dblab.twitterclone.account.Account;
+import me.dblab.twitterclone.account.AccountDto;
+import me.dblab.twitterclone.account.AccountRepository;
+import me.dblab.twitterclone.account.AccountService;
+import me.dblab.twitterclone.common.BaseControllerTest;
+import me.dblab.twitterclone.config.jwt.TokenProvider;
+import me.dblab.twitterclone.tweet.Tweet;
+import me.dblab.twitterclone.tweet.TweetDto;
+import me.dblab.twitterclone.tweet.TweetRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import static org.assertj.core.api.BDDAssertions.then;
+
+@Slf4j
+public class ExploreControllerTests extends BaseControllerTest {
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    TokenProvider tokenProvider;
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    TweetRepository tweetRepository;
+
+    @Autowired
+    AccountService accountService;
+
+    @Autowired
+    ExploreRepository exploreRepository;
+
+    @Autowired
+    ModelMapper modelMapper;
+
+    private final String accountUrl = "/api/users";
+    private final String tweetUrl = "/api/tweets";
+    private final String exploreUrl = "/api/explores";
+    private final String BEARER = "Bearer ";
+
+    private String jwt;
+
+    @BeforeEach
+    @DisplayName("유저 생성 & 트윗 30개 생성")
+    void setUp() {
+        accountRepository.deleteAll().then(exploreRepository.deleteAll()).subscribe();
+
+        AccountDto accountDto = createAccountDto();
+
+        webTestClient.post()
+                .uri(accountUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(accountDto), Account.class)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+
+        Mono<Account> byEmail = accountRepository.findByEmail(appProperties.getTestEmail());
+
+        StepVerifier.create(byEmail)
+                .assertNext(acc -> {
+                    then(acc.getUsername()).isEqualTo(appProperties.getTestUsername());
+                    then(acc.getNickname()).isEqualTo(appProperties.getTestNickname());
+                }).verifyComplete();
+
+        jwt = BEARER + tokenProvider.generateToken(byEmail.block());
+
+        IntStream.rangeClosed(1, 30).forEach(i -> {
+            TweetDto tweetDto = tweetBuilder(i);
+
+            webTestClient.post()
+                    .uri(tweetUrl)
+                    .header(HttpHeaders.AUTHORIZATION, jwt)
+                    .body(Mono.just(tweetDto), Tweet.class)
+                    .exchange()
+                    .expectStatus()
+                    .isCreated();
+        });
+
+        IntStream.rangeClosed(1, 30).forEach(i ->
+                StepVerifier.create(tweetRepository.findAllByAuthorEmail(createEmail(i)))
+                        .assertNext(tw ->
+                                then(tw.getContent()).isEqualTo("게시물" + i)
+                        ));
+    }
+
+    @Test
+    @DisplayName("특정 문자가 포함된 트윗 검색")
+    void exploreTweet() throws Exception {
+        ExploreDto exploreDto = exploreBuilder();
+
+        webTestClient.post()
+                .uri(exploreUrl + "/keywords")
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .body(Mono.just(exploreDto), ExploreDto.class)
+                .exchange()
+                .expectStatus()
+                .isOk();
+
+        Flux<Explore> exploreFlux = exploreRepository.findAllByAccountEmailOrderByKeyword(currentAccount());
+
+        StepVerifier.create(exploreFlux)
+                .assertNext(exp ->
+                        then(exp.isSaved()).isEqualTo(false))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("keyword가 null인 트윗 검색")
+    void exploreTweet_null() throws Exception {
+        ExploreDto exploreDto = new ExploreDto();
+
+        webTestClient.post()
+                .uri(exploreUrl + "/keywords")
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .body(Mono.just(exploreDto), ExploreDto.class)
+                .exchange()
+                .expectStatus()
+                .isOk();
+
+        Flux<Explore> exploreFlux = exploreRepository.findAllByAccountEmailOrderByKeyword(currentAccount());
+
+        StepVerifier.create(exploreFlux)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("검색어 저장")
+    void save_explored_keyword_test() throws Exception {
+        ExploreDto exploreDto = exploreBuilder();
+        saveExplore(exploreDto);
+
+        Flux<Explore> exploreFlux = exploreRepository.findAllByAccountEmailOrderByKeyword(currentAccount());
+
+        StepVerifier.create(exploreFlux)
+                .assertNext(exp -> {
+                    then(exp.getKeyword()).isEqualTo(exploreDto.getKeyword());
+                    then(exp.isSaved()).isEqualTo(true);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("저장할 검색어가 null일 시 BadRequest")
+    void save_explored_keyword_validate() {
+        ExploreDto exploreDto = new ExploreDto();
+
+        webTestClient.post()
+                .uri(exploreUrl)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .body(Mono.just(exploreDto), ExploreDto.class)
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+    }
+
+    @Test
+    @DisplayName("저장된 검색어 불러오기")
+    void get_saved_keyword_test()   {
+        ExploreDto exploreDto = exploreBuilder();
+        saveExplore(exploreDto);
+
+        webTestClient.get()
+                .uri(exploreUrl)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .exchange()
+                .expectStatus()
+                .isOk();
+    }
+
+    @Test
+    @DisplayName("저장된 키워드 삭제")
+    public void delete_saved_keyword_test() throws Exception {
+        ExploreDto exploreDto = exploreBuilder();
+        saveExplore(exploreDto);
+
+        Flux<Explore> exploreFlux = exploreRepository.findAllByAccountEmailOrderByKeyword(currentAccount());
+
+        Explore explore = exploreFlux.blockLast();
+
+        webTestClient.delete()
+                .uri(exploreUrl + "/" + explore.getId())
+                .header(HttpHeaders.AUTHORIZATION,jwt)
+                .exchange()
+                .expectStatus()
+                .isOk();
+
+        StepVerifier.create(exploreRepository.findById(explore.getId()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("다른 유저의 저장된 키워드 삭제")
+    public void delete_another_account_saved_keyword_test() throws Exception {
+        ExploreDto exploreDto = exploreBuilder();
+        saveExplore(exploreDto);
+
+        Flux<Explore> exploreFlux = exploreRepository.findAllByAccountEmailOrderByKeyword(currentAccount());
+        Explore explore = exploreFlux.blockLast();
+        log.info("explore 주인 : " + explore.getAccountEmail());
+        log.info("currentAccount : " + explore.getAccountEmail());
+        AccountDto anotherAccountDto = createAnotherAccountDto();
+
+        webTestClient.post()
+                .uri(accountUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(anotherAccountDto), Account.class)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+
+        Mono<Account> byEmail2 = accountRepository.findByEmail(anotherAccountDto.getEmail());
+        Account account = byEmail2.block();
+        log.info("account : " + account.getEmail());
+        String jwt2 = BEARER + tokenProvider.generateToken(account);
+
+        webTestClient.delete()
+                .uri(exploreUrl + "/" + explore.getId())
+                .header(HttpHeaders.AUTHORIZATION,jwt2)
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+    }
+
+    @Test
+    @DisplayName("잘못된 아이디로 저장된 키워드 삭제할 시 BadRequest")
+    public void delete_saved_keyword_with_invalid_id_test() throws Exception {
+        ExploreDto exploreDto = exploreBuilder();
+        saveExplore(exploreDto);
+
+        webTestClient.delete()
+                .uri(exploreUrl + "/" + UUID.randomUUID().toString())
+                .header(HttpHeaders.AUTHORIZATION,jwt)
+                .exchange()
+                .expectStatus()
+                .isBadRequest();
+    }
+
+    private String currentAccount() throws Exception {
+        Mono<Account> byEmail = accountRepository.findByEmail(tokenProvider.getUsernameFromToken(jwt.replace(BEARER, "")));
+        return Objects.requireNonNull(byEmail.block()).getEmail();
+    }
+
+    private String createEmail(int index) {
+        return "test" + index + "@gmail.com";
+    }
+
+    private TweetDto tweetBuilder(int i) {
+        TweetDto tweetDto = new TweetDto();
+        tweetDto.setContent("게시물" + i);
+        return tweetDto;
+    }
+
+    private ExploreDto exploreBuilder() {
+        ExploreDto exploreDto = new ExploreDto();
+        exploreDto.setKeyword("키워드");
+        return exploreDto;
+    }
+
+    private void saveExplore(ExploreDto exploreDto) {
+        webTestClient.post()
+                .uri(exploreUrl)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .body(Mono.just(exploreDto), ExploreDto.class)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+    }
+
+}


### PR DESCRIPTION
1. `Tweet`의 `content`에 검색한 `keyword`가 포함되어 있으면 해당 `Tweet`들을 불러옴
      - 검색한 키워드가 null일 시 어떠한 `Tweet`도 불러오지 않음
2. 모든 검색어는 DB에 저장되지만 사용자가 직접 저장을 요구한 `keyword`는 `isSaved`상태가 `true`로 저장
      - 저장할 `keyword`가 null일 시 `BAD_REQUEST`
3. 저장된 `keyword`를 삭제할 수 있도록 구현
      - 존재하지 않는 `keyword`를 삭제할 시 `BAD_REQUEST`
      - 다른 유저가 저장한 `keyword`를 삭제할 시 `BAD_REQUEST`

- resolved : #56 
