### PR TITLE
Explore 수정

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountRepository.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountRepository.java
@@ -7,4 +7,5 @@ import reactor.core.publisher.Mono;
 public interface AccountRepository extends ReactiveMongoRepository<Account, String> {
     Mono<Account> findByEmail(String email);
     Flux<Account> findAllByEmail(String email);
+    Flux<Object> findAllByUsernameContainingOrNicknameContainingOrderByCreatedDate(String keyword, String keyword2);
 }

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreController.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreController.java
@@ -1,7 +1,6 @@
 package me.dblab.twitterclone.explore;
 
 import lombok.RequiredArgsConstructor;
-import me.dblab.twitterclone.tweet.Tweet;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Errors;
@@ -23,10 +22,10 @@ public class ExploreController {
     }
 
     @PostMapping("/keywords")
-    public Flux<Tweet> getTweetListBySearch(@RequestBody ExploreDto exploreDto)   {
+    public Flux<Object> getListBySearch(@RequestBody ExploreDto exploreDto)   {
         return Mono.just(exploreDto)
                 .filter(this::validate)
-                .flatMapMany(exploreService::getTweetListByKeyword)
+                .flatMapMany(exploreService::getListByKeyword)
                 .switchIfEmpty(Flux.empty());
     }
 

--- a/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/explore/ExploreService.java
@@ -1,8 +1,8 @@
 package me.dblab.twitterclone.explore;
 
 import lombok.RequiredArgsConstructor;
+import me.dblab.twitterclone.account.AccountRepository;
 import me.dblab.twitterclone.account.AccountService;
-import me.dblab.twitterclone.tweet.Tweet;
 import me.dblab.twitterclone.tweet.TweetRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
@@ -20,6 +20,7 @@ public class ExploreService {
     private final AccountService accountService;
     private final ModelMapper modelMapper;
     private final TweetRepository tweetRepository;
+    private final AccountRepository accountRepository;
 
     public Flux<Explore> getSavedExplore() {
         return accountService.findCurrentUser()
@@ -27,10 +28,11 @@ public class ExploreService {
                         .filter(Explore::isSaved));
     }
 
-    public Flux<Tweet> getTweetListByKeyword(ExploreDto exploreDto) {
+    public Flux<Object> getListByKeyword(ExploreDto exploreDto) {
         return saveExplore(exploreDto)
                 .flatMap(exploreRepository::save)
-                .flatMapMany(exp -> tweetRepository.findAllByContentContainingOrderByCreatedDateDesc(exp.getKeyword()));
+                .flatMapMany(exp -> accountRepository.findAllByUsernameContainingOrNicknameContainingOrderByCreatedDate(exp.getKeyword(), exp.getKeyword())
+                    .mergeWith(tweetRepository.findAllByContentContainingOrderByCreatedDateDesc(exp.getKeyword())));
     }
 
     public Mono<ResponseEntity> saveKeyword(ExploreDto exploreDto) {

--- a/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetRepository.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/tweet/TweetRepository.java
@@ -9,5 +9,5 @@ public interface TweetRepository extends ReactiveMongoRepository<Tweet, String> 
     Flux<Tweet> findAllByAuthorEmailOrderByCreatedDateDesc(String email);
     Flux<Tweet> findAllByAuthorEmail(String email);
     Mono<Tweet> findByAuthorEmail(String email);    // test용
-    Flux<Tweet> findAllByContentContainingOrderByCreatedDateDesc(String keyword);
+    Flux<Object> findAllByContentContainingOrderByCreatedDateDesc(String keyword);
 }

--- a/twitterclone/src/test/java/me/dblab/twitterclone/favorite/FavoriteControllerTests.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/favorite/FavoriteControllerTests.java
@@ -66,7 +66,7 @@ public class FavoriteControllerTests extends BaseControllerTest {
     @BeforeEach
     public void setUp() throws Exception {
 
-        accountRepository.deleteAll().then(favoriteRepository.deleteAll()).subscribe();
+        accountRepository.deleteAll().then(favoriteRepository.deleteAll()).then(tweetRepository.deleteAll()).subscribe();
 
         AccountDto account = createAccountDto();
 


### PR DESCRIPTION
- `/api/explores/keywords`
  - 기존
    - `keyword`가 `Tweet`의 `content`에 속한 `Tweet`들을 불러옴
  - 변경    
    - `keyword`가 `Account`의 `username`과 `nickname`에 속한 `Account`들을 불러옴
    - `keyword`가 `Tweet`의 `content`에 속한 `Tweet`들을 불러옴
    - 불러오는 순서는 `Account`다음 `Tweet` 
    - 반환형을 `Flux<Tweet>`에서 `Flux<Object>`로 변경

- 전체 테스트 코드 실행시 `FavoriteControllerTests`에서 오류
  - `then(tweetRepository.deleteAll())` 추가

- resolved : #60 