### PR TITLE
Password 반환안시키기

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/account/Account.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/account/Account.java
@@ -1,5 +1,6 @@
 package me.dblab.twitterclone.account;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -16,6 +17,7 @@ public class Account {
     private String id;
     private String username;
     private String nickname;
+    @JsonIgnore
     private String password;
     private String email;
     private Date birthDate;

--- a/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountController.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountController.java
@@ -30,8 +30,8 @@ public class AccountController {
     }
 
     @PostMapping("/login")
-    public Mono<ResponseEntity<Jwt>> login(@RequestBody Account account) {
-        return accountService.login(account);
+    public Mono<ResponseEntity<Jwt>> login(@RequestBody AccountDto accountDto) {
+        return accountService.login(accountDto);
     }
 
     @PutMapping("/{accountId}")

--- a/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/account/AccountService.java
@@ -43,10 +43,10 @@ public class AccountService implements ReactiveUserDetailsService {
                         .map(saveUser -> new ResponseEntity<>(saveUser, HttpStatus.CREATED))));
     }
 
-    public Mono<ResponseEntity<Jwt>> login(Account account) {
-        return Mono.just(account)
-                .flatMap(account1 -> accountRepository.findByEmail(account.getEmail()))
-                .filter(account1 -> passwordEncoder.matches(account.getPassword(), account1.getPassword()))
+    public Mono<ResponseEntity<Jwt>> login(AccountDto accountDto) {
+        return Mono.just(accountDto)
+                .flatMap(account1 -> accountRepository.findByEmail(accountDto.getEmail()))
+                .filter(account1 -> passwordEncoder.matches(accountDto.getPassword(), account1.getPassword()))
                 .map(account1 -> new ResponseEntity<>(new Jwt(tokenProvider.generateToken(account1)), HttpStatus.OK))
                 .switchIfEmpty(Mono.just(ResponseEntity.badRequest().build()));
     }

--- a/twitterclone/src/test/java/me/dblab/twitterclone/account/AccountControllerTests.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/account/AccountControllerTests.java
@@ -13,7 +13,9 @@ import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
 import java.util.UUID;
+
 import static org.assertj.core.api.BDDAssertions.then;
 
 @Slf4j
@@ -38,22 +40,25 @@ public class AccountControllerTests extends BaseControllerTest {
     private final String BEARER = "Bearer ";
     private String jwt;
 
-    Mono<Account> byEmail;
-    AccountDto accountDto;
+    private Mono<Account> byEmail;
+    private AccountDto accountDto;
 
     @BeforeEach
     @DisplayName("유저 생성")
-    public void setUp() {
+    void setUp() {
         accountRepository.deleteAll().subscribe();
         accountDto = createAccountDto();
 
         webTestClient.post()
                 .uri(accountUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(accountDto), Account.class)
+                .body(Mono.just(accountDto), AccountDto.class)
                 .exchange()
                 .expectStatus()
-                .isCreated();
+                    .isCreated()
+                .expectBody()
+                    .jsonPath("password")
+                    .doesNotExist();
 
         byEmail = accountRepository.findByEmail(appProperties.getTestEmail());
 
@@ -68,7 +73,7 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("유저 불러오기 테스트")
-    public void get_user_test() {
+    void get_user_test() {
         Account account = byEmail.block();
 
         webTestClient.get()
@@ -81,7 +86,7 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("유저 저장 테스트")
-    public void save_user_test() {
+    void save_user_test() {
         StepVerifier.create(byEmail)
                 .assertNext(account -> {
                     then(account.getUsername()).isEqualTo(appProperties.getTestUsername());
@@ -94,7 +99,7 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("유저 중복 테스트")
-    public void duplicated_user_test()   {
+    void duplicated_user_test()   {
 
         webTestClient.post()
                 .uri(accountUrl)
@@ -106,7 +111,7 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("유저 불러오기 테스트")
-    public void load_user_test() {
+    void load_user_test() {
         Account account = byEmail.block();
 
         webTestClient.get()
@@ -119,16 +124,19 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("유저 수정 테스트")
-    public void update_user_test() {
+    void update_user_test() {
         Account account = byEmail.block();
         AccountDto updatedAccount = updateAccountDto();
 
         webTestClient.put()
                 .uri(accountUrl + "/" + account.getId())
                 .header(HttpHeaders.AUTHORIZATION, jwt)
-                .body(Mono.just(updatedAccount), Account.class)
+                .body(Mono.just(updatedAccount), AccountDto.class)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus()
+                    .isOk()
+                .expectBody()
+                    .jsonPath("password").doesNotExist();
 
         Mono<Account> byId = accountRepository.findById(account.getId());
         Account modifiedAccount = byId.block();
@@ -144,13 +152,13 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("잘못된 유저 수정 테스트")
-    public void update_none_user_test() {
+    void update_none_user_test() {
         AccountDto updatedAccount = updateAccountDto();
 
         webTestClient.put()
                 .uri(accountUrl + "/" + UUID.randomUUID().toString())
                 .header(HttpHeaders.AUTHORIZATION, jwt)
-                .body(Mono.just(updatedAccount), Account.class)
+                .body(Mono.just(updatedAccount), AccountDto.class)
                 .exchange()
                 .expectStatus()
                 .isBadRequest();
@@ -159,7 +167,7 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("유저 삭제 테스트")
-    public void delete_user_test()  {
+    void delete_user_test()  {
         Account account = byEmail.block();
 
         webTestClient.delete()
@@ -172,7 +180,7 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("존재하지않는 유저 삭제 테스트")
-    public void delete_invalid_user_test() throws Exception {
+    void delete_invalid_user_test() throws Exception {
         webTestClient.delete()
                 .uri(accountUrl + "/" + UUID.randomUUID().toString())
                 .header(HttpHeaders.AUTHORIZATION, jwt)
@@ -183,13 +191,13 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("다른 유저를 삭제할 경우")
-    public void delete_another_user_test()  {
+    void delete_another_user_test()  {
         AccountDto anotherAccountDto = createAnotherAccountDto();
 
         webTestClient.post()
                 .uri(accountUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(anotherAccountDto), Account.class)
+                .body(Mono.just(anotherAccountDto), AccountDto.class)
                 .exchange()
                 .expectStatus()
                 .isCreated();
@@ -219,14 +227,12 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("로그인 정상 작동 테스트")
-    public void login_test() {
-        Account account = modelMapper.map(accountDto, Account.class);
-
+    void login_test() {
         //로그인
         webTestClient.post()
                 .uri(accountUrl + "/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(account), Account.class)
+                .body(Mono.just(accountDto), AccountDto.class)
                 .exchange()
                 .expectStatus()
                 .isOk()
@@ -236,14 +242,13 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("저장되지 않은 이메일로 로그인 요청할 때")
-    public void login_test_not_saved_email_400() {
-        Account account = modelMapper.map(accountDto, Account.class);
-        account.setEmail("coffeetank@gmail.com");
+    void login_test_not_saved_email_400() {
+        accountDto.setEmail("coffeetank@gmail.com");
         //로그인
         webTestClient.post()
                 .uri(accountUrl + "/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(account), Account.class)
+                .body(Mono.just(accountDto), AccountDto.class)
                 .exchange()
                 .expectStatus()
                 .isBadRequest();
@@ -251,14 +256,13 @@ public class AccountControllerTests extends BaseControllerTest {
 
     @Test
     @DisplayName("로그인 시 비밀번호가 일치하지 않을 때")
-    public void login_test_not_matches_password_400() {
-        Account account = modelMapper.map(accountDto, Account.class);
-        account.setPassword("americano");
+    void login_test_not_matches_password_400() {
+        accountDto.setPassword("americano");
         //로그인
         webTestClient.post()
                 .uri(accountUrl + "/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(account), Account.class)
+                .body(Mono.just(accountDto), AccountDto.class)
                 .exchange()
                 .expectStatus()
                 .isBadRequest();


### PR DESCRIPTION
기존 코드
- 유저 생성, 수정 시 Account객체가 그대로 반환됨(password포함)

변경된 코드
- 유저 생성, 수정 시 Account객체의 password를 제외한 필드들만 반환

> resolve : #62 