### PR TITLE
front 요구사항

### DIFF
--- a/twitterclone/src/main/java/me/dblab/twitterclone/favorite/FavoriteService.java
+++ b/twitterclone/src/main/java/me/dblab/twitterclone/favorite/FavoriteService.java
@@ -36,7 +36,7 @@ public class FavoriteService {
         return accountService.findCurrentUser()
                             .flatMap(cu ->
                                 favoriteRepository.findByAccountEmailAndTweetId(cu.getEmail(), tweetId)
-                                            .map(favorite1 -> ResponseEntity.badRequest().build())
+                                            .map(favorite1 -> ResponseEntity.badRequest().body(favorite1))
                                             .switchIfEmpty(tweetRepository.findById(tweetId)
                                             .flatMap(tweet -> {
                                                 tweet.setCountLike(tweet.getCountLike() + 1);

--- a/twitterclone/src/test/java/me/dblab/twitterclone/favorite/FavoriteControllerTests.java
+++ b/twitterclone/src/test/java/me/dblab/twitterclone/favorite/FavoriteControllerTests.java
@@ -229,7 +229,11 @@ class FavoriteControllerTests extends BaseControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .exchange()
                 .expectStatus()
-                .isBadRequest();
+                .isBadRequest()
+                .expectBody()
+                .jsonPath("id").exists()
+                .jsonPath("accountEmail").exists()
+                .jsonPath("tweetId").exists();
 
         //Tweet 객체의 좋아요 개수 확인
         StepVerifier.create(tweetRepository.findById(tweet.getId()))


### PR DESCRIPTION
- 좋아요 기능
  - 좋아요를 누른 트윗에 다시 좋아요 요청을 하면 Bad Request가 반환되고,
  프론토는 Bad Request를 반환받으면 다시 좋아요 취소 요청을 하는
  로직인데, 프론트에서 Bad Request를 반환할 때 Favorite 객체를 Body에
  담아 반환해달라는 요청이 있어, 수정함